### PR TITLE
Added rotate buttons

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -242,7 +242,7 @@ class Cropper extends React.Component {
     image.onload = () => {
       context.save();
       context.translate(canvas.width/2,canvas.height/2);
-      context.rotate(90*Math.PI/180);
+      context.rotate(270*Math.PI/180);
       context.drawImage(image,-image.width/2,-image.width/2);
       context.restore();
       this.prepareImage(canvas.toDataURL());
@@ -257,7 +257,7 @@ class Cropper extends React.Component {
     image.onload = () => {
       context.save();
       context.translate(canvas.width/2,canvas.height/2);
-      context.rotate(270*Math.PI/180);
+      context.rotate(90*Math.PI/180);
       context.drawImage(image,-image.width/2,-image.width/2);
       context.restore();
       this.prepareImage(canvas.toDataURL());

--- a/lib/index.js
+++ b/lib/index.js
@@ -235,6 +235,36 @@ class Cropper extends React.Component {
     this.setState({newstate});
   }
 
+  handleRotateLeft (e) {
+    var canvas = this.refs.canvas;
+    var context = this.refs.canvas.getContext("2d");
+    var image = new Image();
+    image.onload = () => {
+      context.save();
+      context.translate(canvas.width/2,canvas.height/2);
+      context.rotate(90*Math.PI/180);
+      context.drawImage(image,-image.width/2,-image.width/2);
+      context.restore();
+      this.prepareImage(canvas.toDataURL());
+    }
+    image.src = canvas.toDataURL();
+  }
+
+  handleRotateRight () {
+    var canvas = this.refs.canvas;
+    var context = this.refs.canvas.getContext("2d");
+    var image = new Image();
+    image.onload = () => {
+      context.save();
+      context.translate(canvas.width/2,canvas.height/2);
+      context.rotate(270*Math.PI/180);
+      context.drawImage(image,-image.width/2,-image.width/2);
+      context.restore();
+      this.prepareImage(canvas.toDataURL());
+    }
+    image.src = canvas.toDataURL();
+  }
+
   render () {
     return (
       <div className="AvatarCropper-canvas">
@@ -244,6 +274,15 @@ class Cropper extends React.Component {
             width={this.props.width}
             height={this.props.height}>
           </canvas>
+        </div>
+
+        <div className="row">
+          <div className="col-md-6">
+            <Button bsStyle="info" onClick={this.handleRotateLeft.bind(this)}>Rotate Left</Button>
+          </div>
+          <div className="col-md-6 pull-right">
+            <Button bsStyle="info" onClick={this.handleRotateRight.bind(this)}>Rotate Right</Button>
+          </div>
         </div>
 
         <div className="row">

--- a/lib/index.js
+++ b/lib/index.js
@@ -31,6 +31,7 @@ class Cropper extends React.Component {
         y: null
       },
       preview: null,
+      originalPreview: null,
       zoom: 1
     };
 
@@ -66,6 +67,11 @@ class Cropper extends React.Component {
       scaledImage.x = 0;
       scaledImage.y = 0;
       this.setState({dragging: false, image: scaledImage, preview: this.toDataURL()});
+      //if this is the first time loading the image, I need to get the original
+      //and store it for rotating, which will allow us to redraw and zoom
+      if(this.state.originalPreview === null){
+        this.setState({originalPreview: this.state.preview})
+      }
     };
     img.src = imageUri;
   }
@@ -235,34 +241,64 @@ class Cropper extends React.Component {
     this.setState({newstate});
   }
 
-  handleRotateLeft (e) {
+  //when rotating, we need to temporarily reset the image to its
+  //original state so that the zoom level and details are not lost
+  resetImage (done) {
     var canvas = this.refs.canvas;
     var context = this.refs.canvas.getContext("2d");
     var image = new Image();
     image.onload = () => {
-      context.save();
-      context.translate(canvas.width/2,canvas.height/2);
-      context.rotate(270*Math.PI/180);
-      context.drawImage(image,-image.width/2,-image.width/2);
-      context.restore();
+      ReactDom.findDOMNode(this.refs.zoom).value = 1;
+      this.handleZoomUpdate();
+      context.drawImage(image,0,0);
       this.prepareImage(canvas.toDataURL());
+      done();
     }
-    image.src = canvas.toDataURL();
+    image.src = this.state.originalPreview;
+  }
+
+  //to rotate either left or right, we first get the current zoom level
+  //and then reset the image to its original state
+  //once reset, we translate the canvas to the middle, draw the original,
+  //rotate, then re-zoom in to the previous level
+  handleRotateLeft () {
+    var currentZoom = ReactDom.findDOMNode(this.refs.zoom).value
+    return this.resetImage(() =>{
+      var canvas = this.refs.canvas;
+      var context = this.refs.canvas.getContext("2d");
+      var image = new Image();
+      image.onload = () => {
+        context.save();
+        context.translate(canvas.width/2,canvas.height/2);
+        context.rotate(270*Math.PI/180);
+        context.drawImage(image,-image.width/2,-image.width/2);
+        context.restore();
+        ReactDom.findDOMNode(this.refs.zoom).value = currentZoom;
+        this.prepareImage(canvas.toDataURL());
+        this.handleZoomUpdate();
+      }
+      image.src = canvas.toDataURL();
+    });
   }
 
   handleRotateRight () {
-    var canvas = this.refs.canvas;
-    var context = this.refs.canvas.getContext("2d");
-    var image = new Image();
-    image.onload = () => {
-      context.save();
-      context.translate(canvas.width/2,canvas.height/2);
-      context.rotate(90*Math.PI/180);
-      context.drawImage(image,-image.width/2,-image.width/2);
-      context.restore();
-      this.prepareImage(canvas.toDataURL());
-    }
-    image.src = canvas.toDataURL();
+    var currentZoom = ReactDom.findDOMNode(this.refs.zoom).value
+    return this.resetImage(() =>{
+      var canvas = this.refs.canvas;
+      var context = this.refs.canvas.getContext("2d");
+      var image = new Image();
+      image.onload = () => {
+        context.save();
+        context.translate(canvas.width/2,canvas.height/2);
+        context.rotate(90*Math.PI/180);
+        context.drawImage(image,-image.width/2,-image.width/2);
+        context.restore();
+        ReactDom.findDOMNode(this.refs.zoom).value = currentZoom;
+        this.prepareImage(canvas.toDataURL());
+        this.handleZoomUpdate();
+      }
+      image.src = canvas.toDataURL();
+    });
   }
 
   render () {


### PR DESCRIPTION
I know you wanted to keep this simple, but we had an issue where images from iOS were automatically rotated. We thought it would be easiest to simply show two rotate buttons in the modal popup allowing users to rotate the image. All I did was add the buttons to the modal (I considered using images or glyph icons, but didn't want to be tied to those) and added two new methods to handle a left rotation and handle a right rotation.

This is my first open source contribution in Javascript and on GitHub, so I hope this was the right flow.

Let me know your thoughts!
