### PR TITLE
add close and crop buttons copy via props

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -261,9 +261,9 @@ class Cropper extends React.Component {
         </div>
 
         <div className='modal-footer'>
-          <Button onClick={this.props.onRequestHide}>Close</Button>
+          <Button onClick={this.props.onRequestHide}>{this.props.closeButtonCopy}</Button>
           <Button bsStyle='primary' onClick={this.handleCrop.bind(this)}>
-            Crop and Save
+            {this.props.cropButtonCopy}
           </Button>
         </div>
 
@@ -306,6 +306,8 @@ class AvatarCropper extends React.Component {
               height={this.props.height}
               onCrop={this.props.onCrop}
               onRequestHide={this.props.onRequestHide}
+              closeButtonCopy={this.props.closeButtonCopy}
+              cropButtonCopy={this.props.cropButtonCopy}
             />
           </div>
 
@@ -319,11 +321,14 @@ class AvatarCropper extends React.Component {
 AvatarCropper.propTypes = {
   image: React.PropTypes.string.isRequired,
   onCrop: React.PropTypes.func.isRequired,
+  closeButtonCopy: React.PropTypes.string,
+  cropButtonCopy: React.PropTypes.string,
   width: numberableType,
   height: numberableType,
   modalSize: React.PropTypes.oneOf(["lg", "large", "sm", "small"]),
   onRequestHide: React.PropTypes.func.isRequired
 };
-AvatarCropper.defaultProps = { width: 400, height: 400, modalSize: "large" };
+AvatarCropper.defaultProps = { width: 400, height: 400, modalSize: "large",
+                               closeButtonCopy: "Close", cropButtonCopy: "Crop and Save"};
 
 export default AvatarCropper;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-avatar-cropper",
-  "version": "0.1.1",
+  "version": "0.1.2",
   "repository": "https://github.com/DropsOfSerenity/react-avatar-cropper",
   "description": "An avatar cropper meant to be a complete solution to avatar cropping.",
   "main": "dist/ReactAvatarCropper.min.js",


### PR DESCRIPTION
Added this pull request to solve this issue https://github.com/DropsOfSerenity/react-avatar-cropper/issues/12.

I would like to add some tests but I noticed that there is no tests on this library.