### PR TITLE
Fix React 15.3 warning.

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react"
   ],
   "dependencies": {
-    "react-bootstrap": "0.27.1",
+    "react-bootstrap": "^0.30.2",
     "warning": "^2.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
upgrade react-bootstrap version to v0.30.2.
https://facebook.github.io/react/warnings/dont-call-proptypes.html