### PR TITLE
Import window to support server-side rendering

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@ import {
 } from "react-bootstrap";
 import {isDataURL} from "./utils";
 import warning from "warning";
+import window from "global/window";
 
 var numberableType = (props, propName, componentName) => {
   warning(

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "react"
   ],
   "dependencies": {
+    "global": "^4.3.1",
     "react-bootstrap": "^0.30.2",
     "warning": "^2.1.0"
   },


### PR DESCRIPTION
Currently, this package is unable to be used in any places that support isomorphic/server rendering.

The current implementation makes the assumption that 'window' exists -- which is not the case on the server, so this small PR accounts for that.
