### PR TITLE
Wrap window assignment calls in typeof condition, in case page is rendered server-side.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,3 +1,5 @@
+/*jshint esversion: 6 */
+
 import "./styles.css";
 import React from "react";
 import ReactDom from "react-dom";
@@ -157,6 +159,7 @@ class Cropper extends React.Component {
 
   componentDidMount () {
     var canvas = ReactDom.findDOMNode(this.refs.canvas);
+    canvas.addEventListener("mousedown", this.listeners.mousedown, false);
     var context = canvas.getContext("2d");
     this.prepareImage(this.props.image);
 
@@ -166,13 +169,12 @@ class Cropper extends React.Component {
       mousedown: e => this.mouseDownListener(e)
     };
 
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       window.addEventListener("mousemove", this.listeners.mousemove, false);
       window.addEventListener("mouseup", this.listeners.mouseup, false);
-      canvas.addEventListener("mousedown", this.listeners.mousedown, false);
     }
 
-    if (typeof document !== 'undefined') {
+    if (typeof document !== "undefined") {
       document.onselectstart = e => this.preventSelection(e);
     }
   }
@@ -181,9 +183,12 @@ class Cropper extends React.Component {
   componentWillUnmount () {
     var canvas = ReactDom.findDOMNode(this.refs.canvas);
 
-    if (typeof window !== 'undefined') {
+    if (typeof window !== "undefined") {
       window.removeEventListener("mousemove", this.listeners.mousemove);
       window.removeEventListener("mouseup", this.listeners.mouseup);
+    }
+
+    if (typeof canvas !== "undefined") {
       canvas.removeEventListener("mousedown", this.listeners.mousedown);
     }
   }

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,18 +166,26 @@ class Cropper extends React.Component {
       mousedown: e => this.mouseDownListener(e)
     };
 
-    window.addEventListener("mousemove", this.listeners.mousemove, false);
-    window.addEventListener("mouseup", this.listeners.mouseup, false);
-    canvas.addEventListener("mousedown", this.listeners.mousedown, false);
-    document.onselectstart = e => this.preventSelection(e);
+    if (typeof window !== 'undefined') {
+      window.addEventListener("mousemove", this.listeners.mousemove, false);
+      window.addEventListener("mouseup", this.listeners.mouseup, false);
+      canvas.addEventListener("mousedown", this.listeners.mousedown, false);
+    }
+
+    if (typeof document !== 'undefined') {
+      document.onselectstart = e => this.preventSelection(e);
+    }
   }
 
   // make sure we clean up listeners when unmounted.
   componentWillUnmount () {
     var canvas = ReactDom.findDOMNode(this.refs.canvas);
-    window.removeEventListener("mousemove", this.listeners.mousemove);
-    window.removeEventListener("mouseup", this.listeners.mouseup);
-    canvas.removeEventListener("mousedown", this.listeners.mousedown);
+
+    if (typeof window !== 'undefined') {
+      window.removeEventListener("mousemove", this.listeners.mousemove);
+      window.removeEventListener("mouseup", this.listeners.mouseup);
+      canvas.removeEventListener("mousedown", this.listeners.mousedown);
+    }
   }
 
   componentDidUpdate () {


### PR DESCRIPTION
Eliminates issues with regards to Universal JavaScript React implementations, where `window` may not exist.