### PR TITLE
Update package.json react-bootstrap to 0.32.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "react"
   ],
   "dependencies": {
-    "react-bootstrap": "^0.30.2",
+    "react-bootstrap": "^0.32.0",
     "warning": "^2.1.0"
   },
   "peerDependencies": {


### PR DESCRIPTION
React.PropTypes has been removed in React 16. This commit will fix errors caused by the react-bootstrap dependency.

This should be used in conjunction with https://github.com/DropsOfSerenity/react-avatar-cropper/pull/33 to fix the PropTypes issues.
